### PR TITLE
Fixing Airfoil Self-Noise dataset url

### DIFF
--- a/real/airfoil-self-noise/readme.txt
+++ b/real/airfoil-self-noise/readme.txt
@@ -1,1 +1,1 @@
-https://archive.ics.uci.edu/ml/datasets/Airfoil+Self-Noise
+https://archive.ics.uci.edu/dataset/291/airfoil+self+noise


### PR DESCRIPTION
Just fixing a broken url for the Airfoil Self-Noise dataset.